### PR TITLE
Update WizAssetsPluginExtendCDVViewController.m

### DIFF
--- a/platforms/ios/HelloCordova/Plugins/jp.wizcorp.phonegap.plugin.wizSpinnerPlugin/wizSpinner/WizAssetsPluginExtendCDVViewController.m
+++ b/platforms/ios/HelloCordova/Plugins/jp.wizcorp.phonegap.plugin.wizSpinnerPlugin/wizSpinner/WizAssetsPluginExtendCDVViewController.m
@@ -407,10 +407,7 @@
     
     
     int orientation = [UIApplication sharedApplication].statusBarOrientation;
-    
-    if (orientation != 1) {
-        [self rotateCustomLoader:orientation];
-    }
+    [self rotateCustomLoader:orientation];
 
     
     for (UIView*spinnerHolder in [UIApplication sharedApplication].keyWindow.subviews) {


### PR DESCRIPTION
There is no reason why the orientation shouldn't rotate when its 1. This seems like an invalid performance fix for not rotating when the orientation is the same.