### PR TITLE
Fix invalid XML

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
 
     <name>Wizard Spinner Plugin</name>
     
-    <description>This plugin allows you to create native spinners & loaders above your HTML application layer.</description>
+    <description>This plugin allows you to create native spinners &amp; loaders above your HTML application layer.</description>
     
     <author>Ally Ogilvie - aogilvie@wizcorp.jp</author>
     


### PR DESCRIPTION
This fixes this issue: https://github.com/Wizcorp/phonegap-plugin-wizSpinner/issues/32
I have tested it on my local install and the plugin now installs correctly
